### PR TITLE
Update repository clone URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Turn any YouTube video into a comprehensive documentation link that AI coding to
 
 ```bash
 # Clone the repository
-git clone https://github.com/your-username/youtubedoc.git
+git clone https://github.com/filiksyos/Youtube-to-Doc.git
 cd youtubedoc
 
 # Run with Docker Compose
@@ -44,7 +44,7 @@ docker-compose up -d
 
 ```bash
 # Clone the repository
-git clone https://github.com/your-username/youtubedoc.git
+git clone https://github.com/filiksyos/Youtube-to-Doc.git
 cd youtubedoc
 
 # Install dependencies (using pnpm as specified in requirements)


### PR DESCRIPTION
Replaced placeholder GitHub URLs with the actual repository URL in the clone instructions to improve accuracy and usability.